### PR TITLE
Feature/adding errors

### DIFF
--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -349,3 +349,75 @@ class Line(Element):
             element.ksl += [0] * (len(ksl) - len(element.ksl))
         for i, component in enumerate(ksl):
             element.ksl[i] += component
+
+    def apply_madx_errors(self, error_table):
+        '''Applies MAD-X error_table (with multipole errors,
+        dx and dy offset errors and dpsi tilt errors)
+        to existing elements in this Line instance.
+
+        Return error_table names which were not found in the
+        elements of this Line instance (and thus not treated).
+
+        Example via cpymad:
+            madx = cpymad.madx.Madx()
+
+            # (...set up lattice and errors in cpymad...)
+
+            seq = madx.sequence.some_lattice
+            # store already applied errors:
+            madx.command.esave(file='lattice_errors.err')
+            madx.command.readtable(
+                file='lattice_errors.err', table="errors")
+            errors = madx.table.errors
+
+            pysixtrack_line, _ = Line.from_madx_sequence(seq)
+            pysixtrack_line.apply_madx_errors(errors)
+        '''
+        max_multipole_err = 0
+        # check for errors in table which cannot be treated yet:
+        for error_type in error_table.keys():
+            if error_type == 'name':
+                continue
+            if any(error_table[error_type]):
+                if error_type in ['dx', 'dy', 'dpsi']:
+                    # available alignment error
+                    continue
+                elif error_type[:1] == 'k' and error_type[-1:] == 'l':
+                    # available multipole error
+                    order = int(''.join(c for c in error_type if c.isdigit()))
+                    max_multipole_err = max(max_multipole_err, order)
+                else:
+                    print (f'Warning: MAD-X error type "{error_type}"'
+                           ' not implemented yet.')
+
+        elements_not_found = []
+        for i_line, element_name in enumerate(error_table['name']):
+            if not element_name in self.element_names:
+                elements_not_found.append(element_name)
+                continue
+            element = self.elements[self.element_names.index(element_name)]
+
+            # add offset
+            try:
+                dx = error_table['dx'][i_line]
+            except KeyError:
+                dx = 0
+            try:
+                dy = error_table['dy'][i_line]
+            except KeyError:
+                dy = 0
+            self.add_offset_error_to(element, dx, dy)
+
+            # add tilt
+            try:
+                dpsi = error_table['dpsi'][i_line]
+                self.add_tilt_error_to(element, dpsi)
+            except KeyError:
+                pass
+
+            # add multipole error
+            knl = [error_table[f'k{o}l' ][i_line] for o in range(max_multipole_err + 1)]
+            ksl = [error_table[f'k{o}sl'][i_line] for o in range(max_multipole_err + 1)]
+            self.add_multipole_error_to(element, knl, ksl)
+
+        return elements_not_found

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -317,8 +317,8 @@ class Line(Element):
         el_name = self.element_names[idx_el]
         if not dx and not dy:
             return
-        xyshift = elements.XYShift(dx=-dx, dy=-dy)
-        inv_xyshift = elements.XYShift(dx=dx, dy=dy)
+        xyshift = elements.XYShift(dx=dx, dy=dy)
+        inv_xyshift = elements.XYShift(dx=-dx, dy=-dy)
         self.insert_element(idx_el, xyshift, el_name + '_offset_in')
         self.insert_element(idx_el + 2, inv_xyshift, el_name + '_offset_out')
 
@@ -328,8 +328,8 @@ class Line(Element):
         el_name = self.element_names[idx_el]
         if not angle:
             return
-        srot = elements.SRotation(angle=-angle)
-        inv_srot = elements.SRotation(angle=angle)
+        srot = elements.SRotation(angle=angle)
+        inv_srot = elements.SRotation(angle=-angle)
         self.insert_element(idx_el, srot, el_name + '_tilt_in')
         self.insert_element(idx_el + 2, inv_srot, el_name + '_tilt_out')
 
@@ -411,7 +411,7 @@ class Line(Element):
             # add tilt
             try:
                 dpsi = error_table['dpsi'][i_line]
-                self.add_tilt_error_to(element, dpsi)
+                self.add_tilt_error_to(element, angle=dpsi * 180 / np.pi)
             except KeyError:
                 pass
 

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -65,6 +65,11 @@ class Line(Element):
             el.track(p)
         return out
 
+    def insert_element(self, idx, element, name):
+        self.elements.insert(idx, element)
+        self.element_names.insert(idx, name)
+        assert len(self.elements) == len(self.element_names)
+
     def append_element(self, element, name):
         self.elements.append(element)
         self.element_names.append(name)

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -317,8 +317,8 @@ class Line(Element):
         el_name = self.element_names[idx_el]
         if not dx and not dy:
             return
-        xyshift = pysixtrack.elements.XYShift(dx=-dx, dy=-dy)
-        inv_xyshift = pysixtrack.elements.XYShift(dx=dx, dy=dy)
+        xyshift = elements.XYShift(dx=-dx, dy=-dy)
+        inv_xyshift = elements.XYShift(dx=dx, dy=dy)
         self.insert_element(idx_el, xyshift, el_name + '_offset_in')
         self.insert_element(idx_el + 2, inv_xyshift, el_name + '_offset_out')
 
@@ -328,8 +328,8 @@ class Line(Element):
         el_name = self.element_names[idx_el]
         if not angle:
             return
-        srot = pysixtrack.elements.SRotation(angle=-angle)
-        inv_srot = pysixtrack.elements.SRotation(angle=angle)
+        srot = elements.SRotation(angle=-angle)
+        inv_srot = elements.SRotation(angle=angle)
         self.insert_element(idx_el, srot, el_name + '_tilt_in')
         self.insert_element(idx_el + 2, inv_srot, el_name + '_tilt_out')
 

--- a/pysixtrack/line.py
+++ b/pysixtrack/line.py
@@ -309,7 +309,7 @@ class Line(Element):
             line, sequence, classes, ignored_madtypes, exact_drift
         )
 
-    ### error handling (alignment, multipole orders, ...)
+    # error handling (alignment, multipole orders, ...):
 
     def add_offset_error_to(self, element, dx=0, dy=0):
         # will raise error if element not present:
@@ -387,7 +387,7 @@ class Line(Element):
                     order = int(''.join(c for c in error_type if c.isdigit()))
                     max_multipole_err = max(max_multipole_err, order)
                 else:
-                    print (f'Warning: MAD-X error type "{error_type}"'
+                    print(f'Warning: MAD-X error type "{error_type}"'
                            ' not implemented yet.')
 
         elements_not_found = []
@@ -416,8 +416,10 @@ class Line(Element):
                 pass
 
             # add multipole error
-            knl = [error_table[f'k{o}l' ][i_line] for o in range(max_multipole_err + 1)]
-            ksl = [error_table[f'k{o}sl'][i_line] for o in range(max_multipole_err + 1)]
+            knl = [error_table[f'k{o}l'][i_line]
+                   for o in range(max_multipole_err + 1)]
+            ksl = [error_table[f'k{o}sl'][i_line]
+                   for o in range(max_multipole_err + 1)]
             self.add_multipole_error_to(element, knl, ksl)
 
         return elements_not_found

--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -146,7 +146,7 @@ def _from_madx_sequence(
             else:
                 newele = myDrift(length=ee.l)
         else:
-            raise ValueError("Not recognized")
+            raise ValueError(f"MAD element \"{mad_etype}\" not recognized")
 
         line.elements.append(newele)
         line.element_names.append(eename)

--- a/pysixtrack/loader_mad.py
+++ b/pysixtrack/loader_mad.py
@@ -8,7 +8,7 @@ def _from_madx_sequence(
 ):
 
     if exact_drift:
-        myDrift = classes.ExactDrift
+        myDrift = classes.DriftExact
     else:
         myDrift = classes.Drift
     seq = sequence


### PR DESCRIPTION
The PR adds an approach to add MAD-X lattice errors (from a `cpymad` exposed error table e.g. via ESAVE) to an existing line. For now this supports 
a) `XYShift` for offsets (`dx, dy` in MAD-X), 
b) `SRotation` for tilts (`dpsi` in MAD-X) and 
c) multipole errors (`k1-20l` and `k1-20sl` in MAD-X).

The following should be confirmed before merging: 
1) elements with both offset and tilt error: the inner tilt wrapping the element is wrapped by an outer offset: e.g. `Multipole` --> `XYShift` + `SRotation` + `Multipole` + `SRotation` + `XYShift`
2) the offset is inverted: a positive `dx` or `dy` error for a MAD-X element leads to a negative shift in the particle coordinate when entering
3) the tilt is inverted: a positive `dpsi` error for a MAD-X element leads to a negative angle in the `SRotation` when entering